### PR TITLE
explicity close url connection once request is completed

### DIFF
--- a/wit.sdk/src/main/java/ai/wit/sdk/WitSpeechRequestTask.java
+++ b/wit.sdk/src/main/java/ai/wit/sdk/WitSpeechRequestTask.java
@@ -29,6 +29,7 @@ public class WitSpeechRequestTask extends AsyncTask<InputStream, String, String>
     private final String AUTHORIZATION_HEADER = "Authorization";
     private final String ACCEPT_HEADER = "Accept";
     private final String CONTENT_TYPE_HEADER = "Content-Type";
+    private final String CONNECTION_HEADER = "Connection";
     private final String TRANSFER_ENCODING_HEADER = "Transfer-Encoding";
     private final String ACCEPT_VERSION = "application/vnd.wit." + WitRequest.version;
     private final String BEARER_FORMAT = "Bearer %s";
@@ -61,6 +62,7 @@ public class WitSpeechRequestTask extends AsyncTask<InputStream, String, String>
             urlConnection.setRequestProperty(AUTHORIZATION_HEADER, String.format(BEARER_FORMAT, _accessToken));
             urlConnection.setRequestProperty(ACCEPT_HEADER, ACCEPT_VERSION);
             urlConnection.setRequestProperty(CONTENT_TYPE_HEADER, _contentType);
+            urlConnection.setRequestProperty(CONNECTION_HEADER, "close");
             urlConnection.setRequestProperty(TRANSFER_ENCODING_HEADER, "chunked");
             urlConnection.setChunkedStreamingMode(0);
 


### PR DESCRIPTION
Occasionally, I get an error like `javax.net.ssl.SSLException: Write error: ssl=0x594e9b00: I/O error during system call, Broken pipe`.

Apparently, this happens when Android attempts to recycle old connections (SSL connections are quite expensive to create, but the overhead to keep them around isn't so bad). I fixed this my explicitly closing the connection after the request is completed.
