### PR TITLE
Android 6.0 fix on IndexoutofBounds - witmic.java

### DIFF
--- a/wit.sdk/src/main/java/ai/wit/sdk/WitMic.java
+++ b/wit.sdk/src/main/java/ai/wit/sdk/WitMic.java
@@ -205,7 +205,7 @@ public class WitMic {
                             _stopHandler.sendEmptyMessage(0);
                         }
                     }
-                    bytes = ShortToByte_Twiddle_Method(buffer);
+                    bytes = short2byte(buffer);
                     if (_streamingStarted) {
                         iOut.write(bytes, 0, nb * 2);
                     } else {
@@ -222,18 +222,8 @@ public class WitMic {
             _witMic.VadClean();
         }
 
-       /* protected byte[] short2byte(short[] shorts, int nb)
-        {
-            int i = 0;
-            ByteBuffer byteBuf = ByteBuffer.allocate(2*nb);
-            while (nb >= i) {
-                byteBuf.putShort(shorts[i]);
-                i++;
-            }
-            return byteBuf.array();
-        }*/
 
-        byte [] ShortToByte_Twiddle_Method(short [] input)
+        byte [] short2byte(short [] input)
         {
             int short_index, byte_index;
             int iterations = input.length;
@@ -253,17 +243,6 @@ public class WitMic {
             return buffer;
         }
 
-
-       /* byte[] MyShortToByte(short[] buffer) {
-            int N = buffer.length;
-            ByteBuffer byteBuf = ByteBuffer.allocate(N);
-            while (N >= i)
-                byte b = (byte)(buffer[i]/256);
-                byteBuf.put(b);
-                i++;
-            }
-            return byteBuf.array();
-        }*/
 
         protected int streamPastBuffers(byte[][] pastBuffers) throws IOException {
             int length = pastBuffers.length;

--- a/wit.sdk/src/main/java/ai/wit/sdk/WitMic.java
+++ b/wit.sdk/src/main/java/ai/wit/sdk/WitMic.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.lang.Thread;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 
@@ -204,7 +205,7 @@ public class WitMic {
                             _stopHandler.sendEmptyMessage(0);
                         }
                     }
-                    short2byte(buffer, nb, bytes);
+                    bytes = ShortToByte(buffer);
                     if (_streamingStarted) {
                         iOut.write(bytes, 0, nb * 2);
                     } else {
@@ -228,6 +229,21 @@ public class WitMic {
                 bytes[i * 2 + 1] = (byte)((shorts[i] >> 8) & 0xff);
             }
         }
+
+         byte [] ShortToByte(short [] input)
+         {
+             int index;
+             int iterations = input.length;
+
+             ByteBuffer bb = ByteBuffer.allocate(input.length * 2);
+
+             for(index = 0; index != iterations; ++index)
+             {
+                 bb.putShort(input[index]);
+             }
+
+             return bb.array();
+         }
 
          protected int streamPastBuffers(byte[][] pastBuffers) throws IOException {
              int length = pastBuffers.length;


### PR DESCRIPTION
Changed method to convert short arrays into a byte array into another one so it won't trigger an IndexOutOfBounds exception. Had to change it a bit in order to avoid some noise
